### PR TITLE
upgraded to use latest version of pogo that does not require bluebird

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+public/
 .*.sw?

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
     "rimraf": "~2.2.8"
   },
   "devDependencies": {
-    "bluebird": "^2.3.2",
     "mocha": "^1.21.4",
-    "pogo": "^0.9.5",
+    "pogo": "^0.10.0",
     "should": "^4.0.4"
   },
   "scripts": {


### PR DESCRIPTION
removed bluebird as a dependancy (it should have been an actual
dependency, not just a devDependeny - it breaks if your project doesn't
have bluebird)
